### PR TITLE
Fix Version of Release Tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.0.1] 2022-02-03
 
 ### Added
+- Initial Code Import
+- Sample Application
+- Test Cases & Infrastructure
 
 ### Changed
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,8 +67,10 @@ pipeline {
       steps {
         updateVersion("CHANGELOG.md", "${BUILD_NUMBER}")
         sh '''
+          cp VERSION VERSION.original
           version="$(<VERSION)"
           echo "${version}-SNAPSHOT" >> VERSION
+          cp VERSION VERSION.snapshot
         '''
       }
     }
@@ -134,7 +136,7 @@ pipeline {
       }
     }
 
-    stage('SpringBootExample') {
+    stage('Release') {
       when {
         expression {
           MODE == "RELEASE"
@@ -142,6 +144,8 @@ pipeline {
       }
 
       steps {
+        // VERSION-SNAPSHOT is not valid for the release process.
+        sh 'cp VERSION.original VERSION'
         release { billOfMaterialsDirectory, assetDirectory ->
           // Publish release artifacts to all the appropriate locations
           // Copy any artifacts to assetDirectory to attach them to the Github release


### PR DESCRIPTION
Maven uses versions with -SNAPSHOT postfix to denote pre-releases,
but that isn't a valid tag format for the release process.

This commit removes the -SNAPSHOT prefix before releasing.