### PR TITLE
Add v prefix to source version during promotion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ if (params.MODE == "PROMOTE") {
 
     sh """
       set -exuo pipefail
-      git checkout "${sourceVersion}"
+      git checkout "v${sourceVersion}"
       echo "${targetVersion}" > VERSION
       ./build-package.sh
       summon ./publish.sh


### PR DESCRIPTION
Source version is not the same as a tag name, the tag has
the v prefix but the version does not. In order to checkout
the source version, the v must be added.
