### PR TITLE
Set ASSET_DIR in promotion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,10 +18,14 @@ if (params.MODE == "PROMOTE") {
     // Any publishing of targetVersion artifacts occur here
     // Anything added to assetDirectory will be attached to the Github Release
 
+    // Pass assetDirectory through to publish.sh as an env var.
+    env.ASSET_DIR=assetDirectory
+
     sh """
       set -exuo pipefail
       git checkout "v${sourceVersion}"
       echo "${targetVersion}" > VERSION
+      cp VERSION VERSION.original
       ./build-tools-image.sh
       ./build-package.sh
       summon ./publish.sh

--- a/SpringBootExample/build-sampleapp-image.sh
+++ b/SpringBootExample/build-sampleapp-image.sh
@@ -26,8 +26,8 @@ docker run \
     tools \
         mvn --batch-mode install:install-file \
         -Dfile="${jar}" \
-        -DgroupId=com.cyberark.conjur.springboot \
-        -DartifactId=Spring-boot-conjur \
+        -DgroupId=com.cyberark \
+        -DartifactId=conjur-sdk-springboot \
         -Dversion="$(<../VERSION)" \
         -Dpackaging=jar \
         -DgeneratePom=true
@@ -38,7 +38,7 @@ docker run \
     --volume "${PWD}/maven_cache":/root/.m2 \
     --workdir "${PWD}" \
     tools \
-        mvn --batch-mode -f pom.xml versions:use-dep-version -Dincludes=com.cyberark.conjur.springboot:Spring-boot-conjur -DdepVersion="$(<../VERSION)"
+        mvn --batch-mode -f pom.xml versions:use-dep-version -Dincludes=com.cyberark:conjur-sdk-springboot -DdepVersion="$(<../VERSION)"
 
 docker run \
     --volume "${PWD}:${PWD}" \

--- a/SpringBootExample/build-sampleapp-image.sh
+++ b/SpringBootExample/build-sampleapp-image.sh
@@ -5,14 +5,27 @@ set -x
 
 mkdir -p maven_cache
 
-cp ../target/*.jar spring-boot-conjur.jar
+# Find the plugin jar
+# Array variable to force glob expansion during assignment
+jar_paths=(../target/*$(<../VERSION).jar)
+
+# Get first item from the array
+jar_path="${jar_paths[0]}"
+
+# Extract jar filename from path
+jar="$(basename "${jar_path}")"
+
+# Bring the spring boot conjur jar into this directory so
+# it is accessible to docker.
+cp "${jar_path}" "${jar}"
+
 docker run \
     --volume "${PWD}:${PWD}" \
     --volume "${PWD}/maven_cache":/root/.m2 \
     --workdir "${PWD}" \
     tools \
         mvn --batch-mode install:install-file \
-        -Dfile=spring-boot-conjur.jar \
+        -Dfile="${jar}" \
         -DgroupId=com.cyberark.conjur.springboot \
         -DartifactId=Spring-boot-conjur \
         -Dversion="$(<../VERSION)" \

--- a/SpringBootExample/pom.xml
+++ b/SpringBootExample/pom.xml
@@ -4,7 +4,6 @@
 	<artifactId>SpringBootExample</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 
-
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
@@ -21,9 +20,6 @@
 		<rest.assured.version>2.3.3</rest.assured.version>
 	</properties>
 
-	
-
-
 	<dependencies>
 
 	<dependency>
@@ -33,8 +29,6 @@
     <scope>test</scope>
 </dependency>
 
-	
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
@@ -42,13 +36,11 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.cyberark.conjur.springboot</groupId>
-			<artifactId>Spring-boot-conjur</artifactId>
+			<groupId>com.cyberark</groupId>
+			<artifactId>conjur-sdk-springboot</artifactId>
 			<!-- This will be updated by build-sampleapp-image.sh -->
 			<version>4.5.7</version>
 		</dependency>
-
-	
 
 		<dependency>
 			<groupId>com.jayway.restassured</groupId>
@@ -56,7 +48,6 @@
 			<version>${rest.assured.version}</version>
 			<scope>test</scope>
 		</dependency>
-
 
 		<dependency>
 			<groupId>javax.xml.bind</groupId>
@@ -83,7 +74,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				
+
 				<dependencies>
 					<dependency>
 						<groupId>org.springframework</groupId>
@@ -96,7 +87,5 @@
 
 		</plugins>
 	</build>
-
-
 
 </project>

--- a/SpringBootExample/start
+++ b/SpringBootExample/start
@@ -53,10 +53,6 @@ docker-compose run \
 
 sleep 2
 
-#docker-compose up --exit-code-from app app 
-
-#docker-compose up --exit-code-from app app 
-
 docker-compose run \
   --volume "$(git rev-parse --show-toplevel):/repo" \
   --volume "${PWD}/maven_cache":/root/.m2 \
@@ -68,7 +64,7 @@ docker-compose run \
   --rm \
   --entrypoint /bin/bash \
 app \
--ec 'mvn -f pom.xml jacoco:prepare-agent test jacoco:report'
+  -ec 'mvn --batch-mode -f pom.xml jacoco:prepare-agent test jacoco:report'
 
- 
+
  cp ../target/site/jacoco/jacoco.xml ../src/main/java

--- a/build-package.sh
+++ b/build-package.sh
@@ -29,11 +29,3 @@ docker run \
     --workdir "${PWD}" \
     tools \
         mvn --batch-mode -f pom.xml package -Dmaven.test.skip
-
-# Remove javadoc jar so only the target jar remains.
-docker run \
-    --volume "${PWD}:${PWD}" \
-    --volume "${PWD}/maven_cache":/root/.m2 \
-    --workdir "${PWD}" \
-    tools \
-        rm -f target/*-javadoc.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.cyberark.conjur.springboot</groupId>
-	<artifactId>Spring-boot-conjur</artifactId>
+	<groupId>com.cyberark</groupId>
+	<artifactId>conjur-sdk-springboot</artifactId>
 
 	<!--
 		DO NOT UPDATE THE VERSION HERE
@@ -16,7 +16,7 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
-	<name>Spring Boot SDK</name>
+	<name>Conjur Spring Boot SDK</name>
 	<description>Conjur Credentials Provider for Spring Boot Applications</description>
 
 	<licenses>

--- a/publish.sh
+++ b/publish.sh
@@ -23,7 +23,7 @@ fi
 
 mkdir -p maven_cache
 
-if grep SNAPSHOT VERSION; then
+if grep SNAPSHOT VERSION.original; then
     echo "Snapshot Version, publishing to internal artifactory"
     maven_profiles="artifactory,sign"
 else


### PR DESCRIPTION
The publish script requires this variable to be set, but it wasn't
set during promotion.

Also:
  * Keep all generated Jars after build, rather than removing
    them. This allows the javadoc jar to be published.
  * Fix logic that determines whether to push to maven
    central or not. Previously it was checking VERSION
    for the phrase "SNAPSHOT" but the file it was checking
    would never contain that phrase.