### PR TITLE
Only push to OSSRH for promote builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ To do so from the source using Maven, follow the setup steps below:
 
 ```xml
        <dependency>
-         <groupId>com.cyberark.conjur.springboot</groupId>
-         <artifactId>Spring-boot-conjur</artifactId>
+         <groupId>com.cyberark</groupId>
+         <artifactId>conjur-sdk-springboot</artifactId>
          <version>1.0.0</version>
       </dependency>
 ```

--- a/publish.sh
+++ b/publish.sh
@@ -23,12 +23,12 @@ fi
 
 mkdir -p maven_cache
 
-if grep SNAPSHOT VERSION.original; then
-    echo "Snapshot Version, publishing to internal artifactory"
-    maven_profiles="artifactory,sign"
-else
-    echo "Non-Snapshot Version, publishing to internal artifactory and ossrh (maven central)"
+if [[ "${MODE:-}" == "PROMOTE" ]]; then
+    echo "PROMOTE build, publishing to internal artifactory and ossrh (maven central)"
     maven_profiles="artifactory,ossrh,sign"
+else
+    echo "Release build, publishing to internal artifactory"
+    maven_profiles="artifactory,sign"
 fi
 
 docker run \


### PR DESCRIPTION
Previously the publish script used the presence of
SNAPSHOT in the VERSION file to determine whether
jars should be pushed to OSSRH. This was unreliable
as SNAPSHOT is stripped from the VERSION file before
the release block is called.
    
This commit uses the MODE environment variable instead.
Jars are only pushed if MODE=PROMOTE.

Also update Readme with new artifact and group IDs. 