### PR TITLE
Add Release to central from OSSRH

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ if (params.MODE == "PROMOTE") {
     sh """
       set -exuo pipefail
       git checkout "v${sourceVersion}"
-      echo "${targetVersion}" > VERSION
+      echo -n "${targetVersion}" > VERSION
       cp VERSION VERSION.original
       ./build-tools-image.sh
       ./build-package.sh

--- a/publish.sh
+++ b/publish.sh
@@ -26,6 +26,7 @@ mkdir -p maven_cache
 if [[ "${MODE:-}" == "PROMOTE" ]]; then
     echo "PROMOTE build, publishing to internal artifactory and ossrh (maven central)"
     maven_profiles="artifactory,ossrh,sign"
+    release_to_central="mvn --settings mvn-settings.xml nexus-staging:release -Dmaven.test.skip=true -P ossrh,sign"
 else
     echo "Release build, publishing to internal artifactory"
     maven_profiles="artifactory,sign"
@@ -43,4 +44,5 @@ docker run \
     --workdir "${PWD}" \
     tools \
         /bin/bash -ec "gpg --batch --passphrase-file /gpg_password --trust-model always --import /gpg_key
-                       mvn --batch-mode  --settings mvn-settings.xml --file pom.xml deploy -Dmaven.test.skip -P ${maven_profiles}"
+                       mvn --batch-mode  --settings mvn-settings.xml --file pom.xml deploy -Dmaven.test.skip -P ${maven_profiles}
+                       ${release_to_central:-}"


### PR DESCRIPTION
Pushing to sonatype oss is not enough for a package to
be included in maven central. To do this nexus-staging:release
must be called via maven.

This commit also fixes an error that caused the release process
to fail as it attempted to create a tag that contained a newline.