### PR TITLE
Fix double release

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can grab the library's dependencies using Maven:
        <dependency>
          <groupId>com.cyberark</groupId>
          <artifactId>conjur-sdk-springboot</artifactId>
-         <version>1.0.0</version>
+         <version>1.0.1</version>
       </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<!--
 		DO NOT UPDATE THE VERSION HERE
 		The current version is stored in the changelog.
-		When the package is built his place holder
+		When the package is built this place holder
 		version will be replaced with the latest version
 		from the changelog.
 

--- a/publish.sh
+++ b/publish.sh
@@ -26,7 +26,6 @@ mkdir -p maven_cache
 if [[ "${MODE:-}" == "PROMOTE" ]]; then
     echo "PROMOTE build, publishing to internal artifactory and ossrh (maven central)"
     maven_profiles="artifactory,ossrh,sign"
-    release_to_central="mvn --settings mvn-settings.xml nexus-staging:release -Dmaven.test.skip=true -P ossrh,sign"
 else
     echo "Release build, publishing to internal artifactory"
     maven_profiles="artifactory,sign"
@@ -44,5 +43,4 @@ docker run \
     --workdir "${PWD}" \
     tools \
         /bin/bash -ec "gpg --batch --passphrase-file /gpg_password --trust-model always --import /gpg_key
-                       mvn --batch-mode  --settings mvn-settings.xml --file pom.xml deploy -Dmaven.test.skip -P ${maven_profiles}
-                       ${release_to_central:-}"
+                       mvn --batch-mode  --settings mvn-settings.xml --file pom.xml deploy -Dmaven.test.skip -P ${maven_profiles}"


### PR DESCRIPTION
When the nexus staging plugin is referenced in the pom, it specifies
auto release. However the publish script also had a manual release
step. This double release, caused the promotion build to fail
as it tried to release twice. This commit removes the manual release.

Also:
  * Update version in Readme
  * Fix a typo in a pom comment