### PR TITLE
Fixed patch of Spring boot app starts at 8181 port and error log for api key and authtoken  

### DIFF
--- a/SpringBootExample/pom.xml
+++ b/SpringBootExample/pom.xml
@@ -18,6 +18,7 @@
 		<java.version>11</java.version>
 		<start-class>com.test.plugin.ConjurClient</start-class>
 		<rest.assured.version>2.3.3</rest.assured.version>
+		<okhttp3.version>4.10.0</okhttp3.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<rest.assured.version>2.3.3</rest.assured.version>
+		<okhttp3.version>4.10.0</okhttp3.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySource.java
+++ b/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySource.java
@@ -35,6 +35,8 @@ public class ConjurPropertySource
 
 	private static String authTokenFile=System.getenv("CONJUR_AUTHN_TOKEN_FILE");
 	
+	private static String authApiKey = System.getenv("CONJUR_AUTHN_API_KEY");
+	
 	private static Logger logger = LoggerFactory.getLogger(ConjurPropertySource.class);
 	/**
 	 * a hack to support seeding environment for the file based api token support in
@@ -44,7 +46,7 @@ public class ConjurPropertySource
 
 		// a hack to support seeding environment for the file based api token support in
 		// downstream java
-		if(authTokenFile!=null) {
+		if (authTokenFile != null) {
 		Map<String, String> conjurParameters = new HashMap<String, String>();
 		byte[] apiKey = null;
 		try (BufferedReader br = new BufferedReader(new FileReader(authTokenFile))){
@@ -71,7 +73,7 @@ public class ConjurPropertySource
 		}
 	
 	}
-	else {
+    else if (authApiKey == null && authTokenFile == null) {
 		 logger.error(ConjurConstant.CONJUR_APIKEY_ERROR);
 
 	}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,5 +5,4 @@ spring.main.show-banner=false
 #logging.level.jdbc.sqltiming=INFO
 #logging.level.jdbc.resultsettable=INFO
 #
-server.port=8181
 spring.main.allow-bean-definition-overriding=true


### PR DESCRIPTION
### Desired Outcome

- Spring boot application is not running in 8181 port .
- User will only get error message , Please provide Conjur Authn Token file or else api Key when not providing both of them.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves # https://github.com/cyberark/conjur-spring-boot-sdk/issues/64

CyberArk internal issue link: https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23326

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
