### PR TITLE
@ConjurPropertySource Not only applied to the properties of a class. 

### DIFF
--- a/src/main/java/com/cyberark/conjur/springboot/annotations/Registrar.java
+++ b/src/main/java/com/cyberark/conjur/springboot/annotations/Registrar.java
@@ -55,7 +55,6 @@ public class Registrar implements ImportBeanDefinitionRegistrar, BeanFactoryPost
 				.getBeansOfType(com.cyberark.conjur.springboot.core.env.ConjurPropertySource.class).values();
 
 		if(beanFactory.getBeanNamesForType(SecretsApi.class).length == 0){
-			ConjurConnectionManager.getInstance();
 			beanFactory.registerSingleton("secretsApi", new SecretsApi());
 		}
 

--- a/src/main/java/com/cyberark/conjur/springboot/annotations/Registrar.java
+++ b/src/main/java/com/cyberark/conjur/springboot/annotations/Registrar.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 
 import com.cyberark.conjur.sdk.endpoint.SecretsApi;
-import com.cyberark.conjur.springboot.core.env.ConjurConnectionManager;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -19,7 +18,6 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MutablePropertySources;
-import org.springframework.core.env.PropertySource;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.MultiValueMap;
 
@@ -53,10 +51,6 @@ public class Registrar implements ImportBeanDefinitionRegistrar, BeanFactoryPost
 
 		Collection<com.cyberark.conjur.springboot.core.env.ConjurPropertySource> beans = beanFactory
 				.getBeansOfType(com.cyberark.conjur.springboot.core.env.ConjurPropertySource.class).values();
-
-		if(beanFactory.getBeanNamesForType(SecretsApi.class).length == 0){
-			beanFactory.registerSingleton("secretsApi", new SecretsApi());
-		}
 
 		for (com.cyberark.conjur.springboot.core.env.ConjurPropertySource ps : beans) {
 

--- a/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySource.java
+++ b/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySource.java
@@ -149,13 +149,11 @@ public class ConjurPropertySource
 		byte[] result = null;
 		if(propertyExists(key)){
 			key = ConjurConfig.getInstance().mapProperty(key);
-			result =  key.getBytes();
 			ConjurConnectionManager.getInstance();
 			try {
 				String secretValue = secretsApi.getSecret(ConjurConstant.CONJUR_ACCOUNT, ConjurConstant.CONJUR_KIND,
 						vaultPath + key);
-				if(secretValue !=null)
-					result = secretValue.getBytes();
+				result = secretValue != null ? secretValue.getBytes() : null;
 			} catch (ApiException ae) {
 				logger.warn("Failed to get property from Conjur for: " + key);
 				logger.warn("Reason: " + ae.getResponseBody());

--- a/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySource.java
+++ b/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySource.java
@@ -3,17 +3,22 @@ package com.cyberark.conjur.springboot.core.env;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.core.env.EnumerablePropertySource;
 
 import com.cyberark.conjur.sdk.ApiException;
 import com.cyberark.conjur.sdk.endpoint.SecretsApi;
 import com.cyberark.conjur.springboot.constant.ConjurConstant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.util.ClassUtils;
 
 
 /**
@@ -32,6 +37,8 @@ public class ConjurPropertySource
 	private String vaultPath = "";
 
 	private SecretsApi secretsApi;
+
+	private List<String> properties;
 
 	private static String authTokenFile=System.getenv("CONJUR_AUTHN_TOKEN_FILE");
 	
@@ -113,10 +120,19 @@ public class ConjurPropertySource
 
 	}
 
-	protected ConjurPropertySource(String vaultPath, String vaultInfo) {
+	protected ConjurPropertySource(String vaultPath, String vaultInfo, AnnotationMetadata importingClassMetadata) throws ClassNotFoundException {
 		super(vaultPath + "@" + vaultInfo);
 		this.vaultPath = vaultPath;
 		this.vaultInfo = vaultInfo;
+		List<String> properties = new ArrayList<>();
+		Class<?> annotatedClass = ClassUtils.forName((importingClassMetadata).getClassName(), getClass().getClassLoader());
+		for (Field field : annotatedClass.getDeclaredFields()) {
+			if (field.isAnnotationPresent(Value.class)) {
+				String value = field.getAnnotation(Value.class).value();
+				properties.add(value);
+			}
+		}
+		this.properties = properties;
 	}
 
 	@Override
@@ -130,24 +146,30 @@ public class ConjurPropertySource
 
 	@Override
 	public Object getProperty(String key) {
-
-		String secretValue = null;
-		key = ConjurConfig.getInstance().mapProperty(key);
-
-		ConjurConnectionManager.getInstance();
-		if (null == secretsApi) {
-			secretsApi = new SecretsApi();
-		}
 		byte[] result = null;
-		try {
-			secretValue = secretsApi.getSecret(ConjurConstant.CONJUR_ACCOUNT, ConjurConstant.CONJUR_KIND,
-					vaultPath + key);
-			result = secretValue != null ? secretValue.getBytes() : null;
-
-		} catch (ApiException ae) {
+		if(propertyExists(key)){
+			key = ConjurConfig.getInstance().mapProperty(key);
+			result =  key.getBytes();
+			ConjurConnectionManager.getInstance();
+			try {
+				String secretValue = secretsApi.getSecret(ConjurConstant.CONJUR_ACCOUNT, ConjurConstant.CONJUR_KIND,
+						vaultPath + key);
+				if(secretValue !=null)
+					result = secretValue.getBytes();
+			} catch (ApiException ae) {
+				logger.warn("Failed to get property from Conjur for: " + key);
+				logger.warn("Reason: " + ae.getResponseBody());
+			}
 		}
 		return result;
-
 	}
-	
+
+	public void setSecretsApi(SecretsApi secretsApi) {
+		this.secretsApi = secretsApi;
+	}
+
+	private boolean propertyExists(String key) {
+		return properties.stream()
+				.anyMatch(property -> property.contains(key));
+	}
 }

--- a/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySource.java
+++ b/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySource.java
@@ -157,6 +157,7 @@ public class ConjurPropertySource
 			} catch (ApiException ae) {
 				logger.warn("Failed to get property from Conjur for: " + key);
 				logger.warn("Reason: " + ae.getResponseBody());
+				logger.warn(ae.getMessage());
 			}
 		}
 		return result;

--- a/src/main/java/com/cyberark/conjur/springboot/processor/SpringBootConjurAutoConfiguration.java
+++ b/src/main/java/com/cyberark/conjur/springboot/processor/SpringBootConjurAutoConfiguration.java
@@ -24,6 +24,12 @@ public class SpringBootConjurAutoConfiguration {
 	ConjurRetrieveSecretService conjurRetrieveSecretService() {
 		return new ConjurRetrieveSecretService();
 	}
+
+	@ConditionalOnMissingBean
+	@Bean
+	SecretsApi secretsApi() {
+		return new SecretsApi();
+	}
 	
 	@ConditionalOnMissingBean
 	@Bean

--- a/src/main/java/com/cyberark/conjur/springboot/processor/SpringBootConjurAutoConfiguration.java
+++ b/src/main/java/com/cyberark/conjur/springboot/processor/SpringBootConjurAutoConfiguration.java
@@ -24,12 +24,6 @@ public class SpringBootConjurAutoConfiguration {
 	ConjurRetrieveSecretService conjurRetrieveSecretService() {
 		return new ConjurRetrieveSecretService();
 	}
-
-	@ConditionalOnMissingBean
-	@Bean
-	SecretsApi secretsApi() {
-		return new SecretsApi();
-	}
 	
 	@ConditionalOnMissingBean
 	@Bean

--- a/src/test/java/com/cyberark/conjur/springboot/ConjurPluginTests.java
+++ b/src/test/java/com/cyberark/conjur/springboot/ConjurPluginTests.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import com.cyberark.conjur.springboot.processor.SpringBootConjurAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,7 +20,7 @@ import com.cyberark.conjur.springboot.annotations.ConjurValues;
 import com.cyberark.conjur.springboot.constant.ConjurConstant;
 import com.cyberark.conjur.springboot.core.env.ConjurConnectionManager;
 
-@SpringBootTest(classes = ConjurPluginTests.class)
+@SpringBootTest(classes = SpringBootConjurAutoConfiguration.class)
 @ConjurPropertySource("db/")
 public class ConjurPluginTests {
 

--- a/src/test/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySourceTest.java
+++ b/src/test/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySourceTest.java
@@ -1,0 +1,53 @@
+package com.cyberark.conjur.springboot.core.env;
+
+import com.cyberark.conjur.sdk.ApiException;
+import com.cyberark.conjur.sdk.endpoint.SecretsApi;
+import com.cyberark.conjur.springboot.annotations.ConjurPropertySource;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author bnasslahsen
+ */
+@SpringBootTest
+public class ConjurPropertySourceTest {
+
+
+	@MockBean
+	private SecretsApi secretsApi;
+
+	@Test
+	public void testGetSecretCallsCount() throws ApiException {
+		// Verify the number of times the method was called
+		verify(secretsApi, times(3)).getSecret(any(), any(),
+				any());
+	}
+
+	@SpringBootApplication
+	static class ConjurPropertySourceTestApp {
+
+		@ConjurPropertySource("db/")
+		@Configuration
+		class ConjurPropertySourceConfiguration {
+
+			@Value("${dbpassWord}")
+			private byte[] dbpassWord;
+
+			@Value("${dbuserName}")
+			private byte[] dbuserName;
+
+			@Value("${key}")
+			private byte[] key;
+		}
+	}
+
+}

--- a/src/test/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySourceTest.java
+++ b/src/test/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySourceTest.java
@@ -3,10 +3,11 @@ package com.cyberark.conjur.springboot.core.env;
 import com.cyberark.conjur.sdk.ApiException;
 import com.cyberark.conjur.sdk.endpoint.SecretsApi;
 import com.cyberark.conjur.springboot.annotations.ConjurPropertySource;
+import com.cyberark.conjur.springboot.core.env.ConjurPropertySourceTest.ConjurPropertySourceConfiguration;
+import com.cyberark.conjur.springboot.processor.SpringBootConjurAutoConfiguration;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
@@ -18,9 +19,8 @@ import static org.mockito.Mockito.verify;
 /**
  * @author bnasslahsen
  */
-@SpringBootTest
+@SpringBootTest(classes = { SpringBootConjurAutoConfiguration.class, ConjurPropertySourceConfiguration.class, ConjurPropertySourceTest.class})
 public class ConjurPropertySourceTest {
-
 
 	@MockBean
 	private SecretsApi secretsApi;
@@ -32,22 +32,18 @@ public class ConjurPropertySourceTest {
 				any());
 	}
 
-	@SpringBootApplication
-	static class ConjurPropertySourceTestApp {
+	@ConjurPropertySource("db/")
+	@Configuration
+	class ConjurPropertySourceConfiguration {
 
-		@ConjurPropertySource("db/")
-		@Configuration
-		class ConjurPropertySourceConfiguration {
+		@Value("${dbpassWord}")
+		private byte[] dbpassWord;
 
-			@Value("${dbpassWord}")
-			private byte[] dbpassWord;
+		@Value("${dbuserName}")
+		private byte[] dbuserName;
 
-			@Value("${dbuserName}")
-			private byte[] dbuserName;
-
-			@Value("${key}")
-			private byte[] key;
-		}
+		@Value("${key}")
+		private byte[] key;
 	}
 
 }


### PR DESCRIPTION
closes #75

### Desired Outcome

- Only a single call should be made to the conjur API for retrieving a secret

### Implemented Changes

- Filtering on properties to make sure, Conjur REST API calls are made only to properties annotated with `ConjurPropertySource`
- Replace `new SecretsApi` by `SecretsApi`  spring bean injection to improve testability of the code
- Replaced empty catch exception block, with logger for better troubleshooting in cases of errors.

#### Startup time:
**Before the fix:**
![Pasted Graphic 2](https://user-images.githubusercontent.com/13404829/230434030-d95d7625-87b9-4621-a297-d90a281229bc.png)
**After the fix:**
![Pasted Graphic 6](https://user-images.githubusercontent.com/13404829/230434058-a51eb27f-be80-4357-b42d-61e259806ddd.png)

#### Conjur REST API CALLs
**Before the fix:**
![Pasted Graphic 3](https://user-images.githubusercontent.com/13404829/230434341-e09deb3d-5032-457c-935e-bb552deec13a.png)
After the fix:
![Pasted Graphic 5](https://user-images.githubusercontent.com/13404829/230434405-860f8a90-590f-4b0c-81a8-90018addc3e2.png)

### Connected Issue/Story

Resolves #75

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
