### PR TITLE
Align authnApiKey property name with the expected environment variables

### DIFF
--- a/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurConnectionManager.java
+++ b/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurConnectionManager.java
@@ -115,7 +115,7 @@ public class ConjurConnectionManager implements EnvironmentAware, BeanFactoryPos
 			String jwtTokenPath = conjurProperties.getJwtTokenPath();
 			String authenticatorId = conjurProperties.getAuthenticatorId();
 			String authnLogin = conjurProperties.getAuthnLogin();
-			String authApiKey = conjurProperties.getAuthApiKey();
+			String authApiKey = conjurProperties.getAuthnApiKey();
 
 			// If jwtTokenPath and authenticatorId are present, the we assume it's JWT Authentication
 			if (StringUtils.isNotEmpty(jwtTokenPath) && StringUtils.isNotEmpty(authenticatorId)) {

--- a/src/main/java/com/cyberark/conjur/springboot/domain/ConjurProperties.java
+++ b/src/main/java/com/cyberark/conjur/springboot/domain/ConjurProperties.java
@@ -26,7 +26,7 @@ public class ConjurProperties{
 	 * The Api key can be injected with CONJUR_AUTHN_API_KEY environment variable
 	 * or spring boot property: conjur.api-key
 	 */
-	private String authApiKey;
+	private String authnApiKey;
 
 	/**
 	 * The Authn login.can be injected with CONJUR_AUTHN_LOGIN environment variable
@@ -169,17 +169,17 @@ public class ConjurProperties{
 	 *
 	 * @return the auth api key
 	 */
-	public String getAuthApiKey() {
-		return authApiKey;
+	public String getAuthnApiKey() {
+		return authnApiKey;
 	}
 
 	/**
 	 * Sets auth api key.
 	 *
-	 * @param authApiKey the auth api key
+	 * @param authnApiKey the auth api key
 	 */
-	public void setAuthApiKey(String authApiKey) {
-		this.authApiKey = authApiKey;
+	public void setAuthnApiKey(String authnApiKey) {
+		this.authnApiKey = authnApiKey;
 	}
 
 	/**
@@ -224,7 +224,7 @@ public class ConjurProperties{
 				"account='" + account + '\'' +
 				", applianceUrl='" + applianceUrl + '\'' +
 				", authTokenFile='" + authTokenFile + '\'' +
-				", authApiKey='" + authApiKey + '\'' +
+				", authnApiKey='" + authnApiKey + '\'' +
 				", authnLogin='" + authnLogin + '\'' +
 				", certFile='" + certFile + '\'' +
 				", sslCertificate='" + sslCertificate + '\'' +

--- a/src/test/java/com/cyberark/conjur/springboot/domain/ConjurPropertiesTest.java
+++ b/src/test/java/com/cyberark/conjur/springboot/domain/ConjurPropertiesTest.java
@@ -1,0 +1,36 @@
+package com.cyberark.conjur.springboot.domain;
+
+import java.lang.reflect.Field;
+
+import com.cyberark.conjur.sdk.ApiClient;
+import com.cyberark.conjur.sdk.endpoint.SecretsApi;
+import com.cyberark.conjur.springboot.processor.SpringBootConjurAutoConfiguration;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static com.cyberark.conjur.springboot.domain.ConjurPropertiesTest.TEST_KEY;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author bnasslahsen
+ */
+@SpringBootTest(classes =SpringBootConjurAutoConfiguration.class)
+@TestPropertySource(properties = { "conjur.authn-api-key="+TEST_KEY })
+public class ConjurPropertiesTest {
+	
+	public static final String TEST_KEY = "TEST_KEY";
+
+	@Autowired
+	private SecretsApi secretsApi;
+	
+	@Test
+	public void testPropertyTest() throws IllegalAccessException {
+		Field apiKeyField = FieldUtils.getDeclaredField(ApiClient.class, "apiKey", true);
+		String apiKey = (String) apiKeyField.get(secretsApi.getApiClient());
+		assertTrue(TEST_KEY.equals(apiKey));
+	}
+}


### PR DESCRIPTION
### Desired Outcome

* The objectif of this PR, is to make sure the  property name in the class `ConjurProperties`, is the same as the environment variable name `CONJUR_AUTHN_API_KEY`

### Implemented Changes

* Renamed `authApiKey` to `authnApiKey`.

### Connected Issue/Story

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
