### PR TITLE
Add missing filters for customPropertySourceChain

### DIFF
--- a/src/main/java/com/cyberark/conjur/springboot/constant/ConjurConstant.java
+++ b/src/main/java/com/cyberark/conjur/springboot/constant/ConjurConstant.java
@@ -57,4 +57,20 @@ public class ConjurConstant {
 	 * The constant SPRING_UTIL
 	 */
 	public static final String SPRING_UTIL = "SPRING_UTIL";
+
+	/**
+	 * The constant ACTUATOR_PREFIX.
+	 */
+	public static final String ACTUATOR_PREFIX = "management";
+
+	/**
+	 * The constant LOGGING_PREFIX.
+	 */
+	public static final String LOGGING_PREFIX = "logging";
+
+	/**
+	 * The constant KUBERNETES_PREFIX.
+	 */
+	public static final String KUBERNETES_PREFIX = "kubernetes";
+	
 }

--- a/src/main/java/com/cyberark/conjur/springboot/service/CustomPropertySourceChain.java
+++ b/src/main/java/com/cyberark/conjur/springboot/service/CustomPropertySourceChain.java
@@ -56,8 +56,8 @@ public class CustomPropertySourceChain extends PropertyProcessorChain {
 
 		if (!(key.startsWith(ConjurConstant.SPRING_VAR)) && !(key.startsWith(ConjurConstant.SERVER_VAR))
 				&& !(key.startsWith(ConjurConstant.ERROR)) && !(key.startsWith(ConjurConstant.SPRING_UTIL))
-				&& !(key.startsWith(ConjurConstant.CONJUR_PREFIX))) {
-
+				&& !(key.startsWith(ConjurConstant.CONJUR_PREFIX)) && !(key.startsWith(ConjurConstant.ACTUATOR_PREFIX))
+				&& !(key.startsWith(ConjurConstant.LOGGING_PREFIX)) && !(key.startsWith(ConjurConstant.KUBERNETES_PREFIX))) {
 			try {
 				String account = ConjurConnectionManager.getAccount(secretsApi);
 				String secretValue = secretsApi.getSecret(account, ConjurConstant.CONJUR_KIND, key);


### PR DESCRIPTION
### Desired Outcome

The objective of this PR, is to add new filters to prevent warning in the logs, related to properties, starting with:
- management
- logging
- kubernetes

At the moment, we get in the logs, when spring-boot-actuator is used:
**"Failed to get property from Conjur for:  management"**

### Implemented Changes

Additional filters added to `CustomPropertySourceChain`


### Definition of Done

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
