### PR TITLE
Enable Autoconfigure imports for spring-boot 3

### DIFF
--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.cyberark.conjur.springboot.processor.SpringBootConjurAutoConfiguration


### PR DESCRIPTION
### Desired Outcome

At the moment, projects needs to add `@Import({ SpringBootConjurAutoConfiguration.class})`

This PR Use `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` for auto-configuration registrations. 

Support for registration in `spring.factories` has been removed in Spring Boot 3 (see https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide section` Auto-configuration Files`).

### Implemented Changes

Add auto-configuration bean to `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
