### PR TITLE
Upgrade Spring Boot Starter Web to 2.7.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
+### Security
+- Upgraded Spring Boot Starter Parent to 2.7.12 and Junit to 5.9.3
+  [conjur-spring-boot-sdk#97](https://github.com/cyberark/conjur-spring-boot-sdk/pull/97)
+
 ## [2.0.0]
 - Plugin now supports Spring Cloud Configuration and to dynamically inject secrets to application.
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,6 +114,7 @@ pipeline {
 
       post {
         always {
+          archiveArtifacts 'SpringBootExample/logs/*'
           junit 'target/surefire-reports/*.xml'
  
           dir ('SpringBootExample') {

--- a/SpringBootExample/pom.xml
+++ b/SpringBootExample/pom.xml
@@ -7,13 +7,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.12</version>
 	</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring-boot.version>2.7.3</spring-boot.version>
-		<spring.version>5.3.13</spring.version>
+		<spring-boot.version>2.7.12</spring-boot.version>
+		<spring.version>5.3.27</spring.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
 		<start-class>com.test.plugin.ConjurClient</start-class>

--- a/SpringBootExample/pom.xml
+++ b/SpringBootExample/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>SpringBootExample</groupId>
 	<artifactId>SpringBootExample</artifactId>
@@ -23,12 +25,12 @@
 
 	<dependencies>
 
-	<dependency>
-    <groupId>org.testcontainers</groupId>
-    <artifactId>testcontainers</artifactId>
-    <version>1.16.3</version>
-    <scope>test</scope>
-</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<version>1.18.3</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/SpringBootExample/start
+++ b/SpringBootExample/start
@@ -1,13 +1,24 @@
 #!/bin/bash -ex
 
-set +x 
+set -x 
 
 rm -rf .env
-docker-compose down -v
 
+get_container_logs(){
+  mkdir -p logs
+  docker-compose ps --format json \
+    |jq -r  '.[]|.Name' \
+    |while read -r container; do \
+      docker logs "${container}" &> "logs/${container}.log"
+    done
+}
+
+trap get_container_logs EXIT
+
+docker-compose down -v
+docker-compose pull conjur pg proxy openssl
 docker-compose build
-docker-compose up -d conjur
-docker-compose up -d proxy
+docker-compose up -d proxy # Don't need to specify conjur here, as proxy depends on conjur
 docker-compose exec -T conjur conjurctl wait -r 240
 
 admin_api_key=$(docker-compose exec -T conjur conjurctl role retrieve-key dev:user:admin | tr -d '\r')

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.12</version>
 	</parent>
 
 	<profiles>
@@ -207,7 +207,7 @@
 			<dependency>
 				<groupId>org.junit</groupId>
 				<artifactId>junit-bom</artifactId>
-				<version>5.8.2</version>
+				<version>5.9.3</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
### Desired Outcome

Remove versions of Spring Framework vulnerable to CVE-2023-20863 (deemed low risk for the conjur spring boot sdk). 

### Implemented Changes

Upgraded spring-boot-starter-web to 2.7.12 (latest version in 2.7.x line. Migration to 3.x will be ticketed separately).
Upgrade junit to 5.9.3 (no security impact).