### PR TITLE
Add property to prevent scanning all @Value annotation by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,16 +333,17 @@ For example:`appliance_url` is `CONJUR_APPLIANCE_URL`, `account` is `CONJUR_ACCO
 
 If no other configuration is done (e.g. over system properties or CLI parameters), include the following environment variables in the app's runtime environment to use the Spring Boot Plugin.
 
-| Name                    | Environment ID          | Description                | API KEY | JWT  |
-| ----------------------- | ----------------------- | -------------------------- | ------- | ---- |
-| Conjur Account          | CONJUR_ACCOUNT          | Account to connect         | Yes     | Yes  |
-| API key                 | CONJUR_AUTHN_API_KEY    | User/host API Key/password | Yes     | No   |
-| Connection url          | CONJUR_APPLIANCE_URL    | Conjur instance to connect | Yes     | Yes  |
-| User/host identity      | CONJUR_AUTHN_LOGIN      | User /host identity        | Yes     | No   |
-| SSL Certificate Path    | CONJUR_CERT_FILE        | Path to certificate file   | Yes     | Yes  |
-| SSL Certificate Content | CONJUR_SSL_CERTIFICATE  | Certificate content        | Yes     | Yes  |
-| Path of the JWT Token   | CONJUR_JWT_TOKEN_PATH   | Path of the JWT Token      | No      | Yes  |
-| Conjur authenticator ID | CONJUR_AUTHENTICATOR_ID | Conjur authenticator ID    | No      | Yes  |
+| Name                    | Environment ID        | Description                                                                         | API KEY | JWT  |
+|-------------------------| --------------------- |-------------------------------------------------------------------------------------| ------- | ---- |
+| Conjur Account          | CONJUR_ACCOUNT        | Account to connect                                                                  | Yes     | Yes  |
+| API key                 | CONJUR_AUTHN_API_KEY  | User/host API Key/password                                                          | Yes     | No   |
+| Connection url          | CONJUR_APPLIANCE_URL  | Conjur instance to connect                                                          | Yes     | Yes  |
+| User/host identity      | CONJUR_AUTHN_LOGIN    | User /host identity                                                                 | Yes     | No   |
+| SSL Certificate Path    | CONJUR_CERT_FILE      | Path to certificate file                                                            | Yes     | Yes  |
+| SSL Certificate Content | CONJUR_SSL_CERTIFICATE | Certificate content                                                                 | Yes     | Yes  |
+| Path of the JWT Token   | CONJUR_JWT_TOKEN_PATH | Path of the JWT Token                                                               | No      | Yes  |
+| Conjur authenticator ID | CONJUR_AUTHENTICATOR_ID | Conjur authenticator ID                                                             | No      | Yes  |
+| Conjur Scan All @Values | CONJUR_SCANALLVALUES | Property to enable Conjur to scan for all  `@Values` annotations - default is `false` | Yes      | Yes  |
 
 Only one CONJUR_CERT_FILE and CONJUR_SSL_CERTIFICATE is required. There are two variables to allow the user to specify the path to a certificate file or provide the certificate data directly in an environment variable.
 </details>

--- a/src/main/java/com/cyberark/conjur/springboot/constant/ConjurConstant.java
+++ b/src/main/java/com/cyberark/conjur/springboot/constant/ConjurConstant.java
@@ -72,5 +72,9 @@ public class ConjurConstant {
 	 * The constant KUBERNETES_PREFIX.
 	 */
 	public static final String KUBERNETES_PREFIX = "kubernetes";
-	
+
+	/**
+	 * The constant CONJUR_SCAN_ALL_VALUES.
+	 */
+	public static final String CONJUR_SCAN_ALL_VALUES = "conjur.scan-all-values";
 }

--- a/src/main/java/com/cyberark/conjur/springboot/domain/ConjurProperties.java
+++ b/src/main/java/com/cyberark/conjur/springboot/domain/ConjurProperties.java
@@ -57,6 +57,11 @@ public class ConjurProperties{
 	private String authenticatorId;
 
 	/**
+	 * The Scan all values.
+	 */
+	private boolean scanAllValues;
+	
+	/**
 	 * Gets account.
 	 *
 	 * @return the account
@@ -218,6 +223,24 @@ public class ConjurProperties{
 		this.authenticatorId = authenticatorId;
 	}
 
+	/**
+	 * Is scan all values boolean.
+	 *
+	 * @return the boolean
+	 */
+	public boolean isScanAllValues() {
+		return scanAllValues;
+	}
+
+	/**
+	 * Sets scan all values.
+	 *
+	 * @param scanAllValues the scan all values
+	 */
+	public void setScanAllValues(boolean scanAllValues) {
+		this.scanAllValues = scanAllValues;
+	}
+
 	@Override
 	public String toString() {
 		return "ConjurProperties{" +
@@ -230,6 +253,7 @@ public class ConjurProperties{
 				", sslCertificate='" + sslCertificate + '\'' +
 				", jwtTokenPath='" + jwtTokenPath + '\'' +
 				", authenticatorId='" + authenticatorId + '\'' +
+				", scanAllValues=" + scanAllValues +
 				'}';
 	}
 }

--- a/src/main/java/com/cyberark/conjur/springboot/processor/SpringBootConjurAutoConfiguration.java
+++ b/src/main/java/com/cyberark/conjur/springboot/processor/SpringBootConjurAutoConfiguration.java
@@ -1,19 +1,21 @@
 package com.cyberark.conjur.springboot.processor;
 
-import static com.cyberark.conjur.springboot.constant.ConjurConstant.CONJUR_PREFIX;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import com.cyberark.conjur.sdk.endpoint.SecretsApi;
 import com.cyberark.conjur.springboot.core.env.AccessTokenProvider;
 import com.cyberark.conjur.springboot.core.env.ConjurConnectionManager;
 import com.cyberark.conjur.springboot.core.env.ConjurPropertySource;
 import com.cyberark.conjur.springboot.domain.ConjurProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.cyberark.conjur.springboot.constant.ConjurConstant.CONJUR_PREFIX;
+import static com.cyberark.conjur.springboot.constant.ConjurConstant.CONJUR_SCAN_ALL_VALUES;
 
 
 @Configuration(proxyBeanMethods = false)
@@ -60,6 +62,7 @@ public class SpringBootConjurAutoConfiguration {
 	
 
 	@ConditionalOnMissingBean(ConjurPropertySource.class)
+	@ConditionalOnProperty(name = CONJUR_SCAN_ALL_VALUES)
 	@Bean
 	static ConjurCloudProcessor conjurCloudProcessor(SecretsApi secretsApi) {
 

--- a/src/test/java/com/cyberark/conjur/springboot/processor/ConjurCloudProcessorScanTest.java
+++ b/src/test/java/com/cyberark/conjur/springboot/processor/ConjurCloudProcessorScanTest.java
@@ -1,0 +1,53 @@
+package com.cyberark.conjur.springboot.processor;
+
+import com.cyberark.conjur.springboot.annotations.ConjurPropertySource;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConjurCloudProcessorScanTest {
+
+	private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+			.withUserConfiguration(SampleApp.class);
+
+	private final WebApplicationContextRunner contextRunnerConjurPropertySource = new WebApplicationContextRunner()
+			.withUserConfiguration(SampleAppConjurPropertySource.class);
+	@Test
+	public void scanning_not_loaded_by_default() {
+		contextRunner
+				.run(context -> assertThat(context)
+						.hasNotFailed()
+						.doesNotHaveBean("conjurCloudProcessor")
+				);
+	}
+
+	@Test
+	public void scanning_loaded_explicitly() {
+		contextRunner
+				.withPropertyValues("conjur.scan-all-values=true")
+				.run(context -> assertThat(context)
+						.hasNotFailed()
+						.hasBean("conjurCloudProcessor")
+				);
+	}
+
+	@Test
+	public void scanning_not_loaded_by_if_conjur_property_source_present() {
+		contextRunnerConjurPropertySource
+				.withPropertyValues("conjur.scan-all-values=true")
+				.run(context -> assertThat(context)
+						.hasNotFailed()
+						.doesNotHaveBean("conjurCloudProcessor")
+				);
+	}
+	
+	@EnableAutoConfiguration
+	static class SampleApp {}
+
+	@EnableAutoConfiguration
+	@ConjurPropertySource(value = "test")
+	static class SampleAppConjurPropertySource {}	
+}


### PR DESCRIPTION
### Desired Outcome

*The goal of this PR is to prevent default scanning of all `@Value` annotations by default*
This can have huge performance impact on application startup: In real customer context, application slowed from 21s to 170s as of too many invalid secrets retrieval. 

With the following code:
![image](https://github.com/cyberark/conjur-spring-boot-sdk/assets/13404829/a7d5bd98-8399-469a-b867-f9bbcd0cdcf8)

Developer will get as result:
![image](https://github.com/cyberark/conjur-spring-boot-sdk/assets/13404829/6cafd2c0-53ff-47b7-971a-b7e66bfbe791)

### Implemented Changes

This PR introduces new property `conjur.scan-all-values` that allow the developer to explicitly enable all `@Value` annotation scanning.
The bean `ConjurCloudProcessor` will be loaded only if `conjur.scan-all-values` is set to true and `ConjurPropertySource` bean is not present.


### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
