### PR TITLE
Making the path of conjur.properties configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,16 @@ nginx.key
 api_key
 .settings/
 **/.settings/
+
+######################
+# Intellij
+######################
+.idea/
+*.iml
+*.iws
+*.ipr
+*.ids
+*.orig
+classes/
+out/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -310,18 +310,18 @@ You can do this by setting Conjur Properties or [Environment variables](#environ
 #### CyberArk Conjur Configuration Properties
 The following configuration properties can be set in the standard `spring-boot` configuration files, `application.properties` or `application.yml`:
 
-| Parameter name           | Description                             |
-|:-------------------------|:----------------------------------------|
-| conjur.account           | CyberArk Conjur Account                 |
-| conjur.appliance-url     | CyberArk Conjur Appliance URL           |
-| conjur.authn-login       | CyberArk Conjur User /host identity     |
-| conjur.authn-api-key     | CyberArk Conjur API KEY of the host     |
-| conjur.auth-token-file   | CyberArk Conjur Token, stored in a file |
-| conjur.cert-file         | CyberArk Conjur SSL Certificate path    |
-| conjur.ssl-certificate   | CyberArk Conjur SSL Certificate Content |
-| conjur.authenticator-id  | CyberArk Conjur authenticator ID        |
-| conjur.jwt-token-path    | CyberArk Conjur Path of the JWT Token   |
-
+| Parameter name          | Description                             |
+|:------------------------|:----------------------------------------|
+| conjur.account          | CyberArk Conjur Account                 |
+| conjur.appliance-url    | CyberArk Conjur Appliance URL           |
+| conjur.authn-login      | CyberArk Conjur User /host identity     |
+| conjur.authn-api-key    | CyberArk Conjur API KEY of the host     |
+| conjur.auth-token-file  | CyberArk Conjur Token, stored in a file |
+| conjur.cert-file        | CyberArk Conjur SSL Certificate path    |
+| conjur.ssl-certificate  | CyberArk Conjur SSL Certificate Content |
+| conjur.authenticator-id | CyberArk Conjur authenticator ID        |
+| conjur.jwt-token-path   | CyberArk Conjur Path of the JWT Token   |
+| conjur.mapping-path     | CyberArk Conjur Mapping Path            |
 	
 <h4 id="environment-variables">
  Environment Variables
@@ -334,7 +334,7 @@ For example:`appliance_url` is `CONJUR_APPLIANCE_URL`, `account` is `CONJUR_ACCO
 If no other configuration is done (e.g. over system properties or CLI parameters), include the following environment variables in the app's runtime environment to use the Spring Boot Plugin.
 
 | Name                    | Environment ID          | Description                | API KEY | JWT  |
-| ----------------------- | ----------------------- | -------------------------- | ------- | ---- |
+|-------------------------|-------------------------|----------------------------| ------- | ---- |
 | Conjur Account          | CONJUR_ACCOUNT          | Account to connect         | Yes     | Yes  |
 | API key                 | CONJUR_AUTHN_API_KEY    | User/host API Key/password | Yes     | No   |
 | Connection url          | CONJUR_APPLIANCE_URL    | Conjur instance to connect | Yes     | Yes  |
@@ -343,6 +343,7 @@ If no other configuration is done (e.g. over system properties or CLI parameters
 | SSL Certificate Content | CONJUR_SSL_CERTIFICATE  | Certificate content        | Yes     | Yes  |
 | Path of the JWT Token   | CONJUR_JWT_TOKEN_PATH   | Path of the JWT Token      | No      | Yes  |
 | Conjur authenticator ID | CONJUR_AUTHENTICATOR_ID | Conjur authenticator ID    | No      | Yes  |
+| Conjur MAPPING PATH     | CONJUR_MAPPING_PATH     | Conjur Mapping PATH        | Yes      | Yes  |
 
 Only one CONJUR_CERT_FILE and CONJUR_SSL_CERTIFICATE is required. There are two variables to allow the user to specify the path to a certificate file or provide the certificate data directly in an environment variable.
 </details>

--- a/src/main/java/com/cyberark/conjur/springboot/annotations/Registrar.java
+++ b/src/main/java/com/cyberark/conjur/springboot/annotations/Registrar.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 
 import com.cyberark.conjur.sdk.endpoint.SecretsApi;
+import com.cyberark.conjur.springboot.core.env.ConjurConfig;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -58,6 +59,7 @@ public class Registrar implements ImportBeanDefinitionRegistrar, BeanFactoryPost
 				continue;
 			}
 			ps.setSecretsApi(beanFactory.getBean(SecretsApi.class));
+			ps.setConjurConfig(beanFactory.getBean(ConjurConfig.class));
 			propertySources.addLast(ps);
 		}
 	}

--- a/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurConfig.java
+++ b/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurConfig.java
@@ -1,12 +1,26 @@
 package com.cyberark.conjur.springboot.core.env;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import com.cyberark.conjur.springboot.constant.ConjurConstant;
+import com.cyberark.conjur.springboot.domain.ConjurProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.util.ResourceUtils;
+
+import static com.cyberark.conjur.springboot.constant.ConjurConstant.CONJUR_PREFIX;
 
 /**
  * 
@@ -14,50 +28,70 @@ import org.slf4j.LoggerFactory;
  * the keys values defined in properties file.
  *
  */
-public class ConjurConfig {
+public class ConjurConfig implements EnvironmentAware, BeanFactoryPostProcessor {
 
 	private static final Properties PROPS = new Properties();
 
-	private static final ConjurConfig UNIQUE_INSTANCE = new ConjurConfig();
-	
 	private static final Logger LOGGER = LoggerFactory.getLogger(ConjurConfig.class);
-	
-	private ConjurConfig() {
-
-		InputStream propsFile = ConjurConfig.class.getResourceAsStream(ConjurConstant.CONJUR_PROPERTIES);
-
-		if (propsFile != null) {
-			try {
-				PROPS.load(propsFile);
-			} catch (IOException e) {
-				LOGGER.error(e.getMessage(), e);
-			} finally {
-				try {
-					propsFile.close();
-				} catch (IOException e) {
-					LOGGER.error(e.getMessage(), e);
-				}
-			}
-		}
-
-	}
-
 	/**
-	 * 
-	 * @return unique instance of class.
+	 * The Environment.
 	 */
-	public static ConjurConfig getInstance() {
-		return UNIQUE_INSTANCE;
-	}
-
+	private Environment environment;
+	
 	/**
-	 * 
+	 *
 	 * @param name - key define at given property file.
 	 * @return - corresponding value of key defined at given property file.
 	 */
 	public String mapProperty(String name) {
 		String mapped = PROPS.getProperty(ConjurConstant.CONJUR_MAPPING + name);
-
 		return mapped != null ? mapped : name;
+	}
+
+	@Override
+	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+		final BindResult<ConjurProperties> result = Binder.get(environment).bind(CONJUR_PREFIX, ConjurProperties.class);
+		if (result.isBound()) {
+			loadMappingProps(result);
+		}
+	}
+
+	@Override
+	public void setEnvironment(Environment environment) {
+		this.environment = environment;
+	}
+	
+	private void loadMappingProps(BindResult<ConjurProperties> result) {
+		String mappingPath = result.get().getMappingPath();
+		InputStream propsFile = null;
+		if (mappingPath != null) {
+			try {
+				File file = ResourceUtils.getFile(mappingPath);
+				propsFile = Files.newInputStream(file.toPath());
+			}
+			catch (IOException e) {
+				LOGGER.error(e.getMessage(), e);
+			}
+		}
+		else {
+			propsFile = ConjurConfig.class.getResourceAsStream(ConjurConstant.CONJUR_PROPERTIES);
+		}
+
+		if (propsFile != null) {
+			try {
+				PROPS.load(propsFile);
+			}
+			catch (IOException e) {
+				LOGGER.error(e.getMessage(), e);
+			}
+			finally {
+				try {
+					propsFile.close();
+				}
+				catch (IOException e) {
+					LOGGER.error(e.getMessage(), e);
+				}
+			}
+		}
 	}
 }

--- a/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySource.java
+++ b/src/main/java/com/cyberark/conjur/springboot/core/env/ConjurPropertySource.java
@@ -30,6 +30,8 @@ public class ConjurPropertySource extends EnumerablePropertySource<Object> {
 	private SecretsApi secretsApi;
 
 	private List<String> properties;
+	
+	private ConjurConfig conjurConfig;
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(ConjurPropertySource.class);
 
@@ -73,7 +75,7 @@ public class ConjurPropertySource extends EnumerablePropertySource<Object> {
 			this.vaultPath = vaultPath.concat("/");
 		}
 		if (propertyExists(key)) {
-			key = ConjurConfig.getInstance().mapProperty(key);
+			key = conjurConfig.mapProperty(key);
 			try {
 				String account = ConjurConnectionManager.getAccount(secretsApi);
 				String secretValue = secretsApi.getSecret(account, ConjurConstant.CONJUR_KIND, vaultPath + key);
@@ -97,5 +99,9 @@ public class ConjurPropertySource extends EnumerablePropertySource<Object> {
 
 	private boolean propertyExists(String key) {
 		return properties.stream().anyMatch(property -> property.contains(key));
+	}
+
+	public void setConjurConfig(ConjurConfig conjurConfig) {
+		this.conjurConfig = conjurConfig;
 	}
 }

--- a/src/main/java/com/cyberark/conjur/springboot/domain/ConjurProperties.java
+++ b/src/main/java/com/cyberark/conjur/springboot/domain/ConjurProperties.java
@@ -57,6 +57,11 @@ public class ConjurProperties{
 	private String authenticatorId;
 
 	/**
+	 * The Conjur mapping path.
+	 */
+	private String mappingPath;
+
+	/**
 	 * Gets account.
 	 *
 	 * @return the account
@@ -218,6 +223,24 @@ public class ConjurProperties{
 		this.authenticatorId = authenticatorId;
 	}
 
+	/**
+	 * Gets conjur mapping path.
+	 *
+	 * @return the conjur mapping path
+	 */
+	public String getMappingPath() {
+		return mappingPath;
+	}
+
+	/**
+	 * Sets conjur mapping path.
+	 *
+	 * @param mappingPath the conjur mapping path
+	 */
+	public void setMappingPath(String mappingPath) {
+		this.mappingPath = mappingPath;
+	}
+
 	@Override
 	public String toString() {
 		return "ConjurProperties{" +
@@ -230,6 +253,7 @@ public class ConjurProperties{
 				", sslCertificate='" + sslCertificate + '\'' +
 				", jwtTokenPath='" + jwtTokenPath + '\'' +
 				", authenticatorId='" + authenticatorId + '\'' +
+				", conjurMappingPath='" + mappingPath + '\'' +
 				'}';
 	}
 }

--- a/src/main/java/com/cyberark/conjur/springboot/processor/ConjurCloudProcessor.java
+++ b/src/main/java/com/cyberark/conjur/springboot/processor/ConjurCloudProcessor.java
@@ -8,6 +8,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 
 import com.cyberark.conjur.sdk.endpoint.SecretsApi;
+import com.cyberark.conjur.springboot.core.env.ConjurConfig;
 import com.cyberark.conjur.springboot.service.CustomPropertySourceChain;
 import com.cyberark.conjur.springboot.service.DefaultPropertySourceChain;
 import com.cyberark.conjur.springboot.service.PropertyProcessorChain;
@@ -31,14 +32,17 @@ public class ConjurCloudProcessor implements BeanPostProcessor, InitializingBean
 
 	private PropertyProcessorChain processorChain;
 
+	private ConjurConfig conjurConfig;
+	
 	@Override
 	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
 		return bean;
 	}
 
-	public ConjurCloudProcessor(SecretsApi secretsApi) {
+	public ConjurCloudProcessor(SecretsApi secretsApi, ConjurConfig conjurConfig) {
 		super();
 		this.secretsApi = secretsApi;
+		this.conjurConfig= conjurConfig;
 	}
 
 	@Override
@@ -48,6 +52,7 @@ public class ConjurCloudProcessor implements BeanPostProcessor, InitializingBean
 		CustomPropertySourceChain customPS = new CustomPropertySourceChain("CustomPropertySource");
 		processorChain.setNextChain(customPS);
 		customPS.setSecretsApi(secretsApi);
+		customPS.setConjurConfig(conjurConfig);
 		environment.getPropertySources().addLast(processorChain);
 
 	}

--- a/src/main/java/com/cyberark/conjur/springboot/processor/SpringBootConjurAutoConfiguration.java
+++ b/src/main/java/com/cyberark/conjur/springboot/processor/SpringBootConjurAutoConfiguration.java
@@ -2,6 +2,7 @@ package com.cyberark.conjur.springboot.processor;
 
 import static com.cyberark.conjur.springboot.constant.ConjurConstant.CONJUR_PREFIX;
 
+import com.cyberark.conjur.springboot.core.env.ConjurConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -61,11 +62,16 @@ public class SpringBootConjurAutoConfiguration {
 
 	@ConditionalOnMissingBean(ConjurPropertySource.class)
 	@Bean
-	static ConjurCloudProcessor conjurCloudProcessor(SecretsApi secretsApi) {
+	static ConjurCloudProcessor conjurCloudProcessor(SecretsApi secretsApi, ConjurConfig conjurConfig) {
 
 		LOGGER.info("Creating ConjurCloudProcessor instance");
 
-		return new ConjurCloudProcessor(secretsApi);
+		return new ConjurCloudProcessor(secretsApi, conjurConfig);
 	}
-	
+
+	@ConditionalOnMissingBean
+	@Bean
+	static ConjurConfig conjurConfig() {
+		return new ConjurConfig();
+	}
 }

--- a/src/main/java/com/cyberark/conjur/springboot/service/CustomPropertySourceChain.java
+++ b/src/main/java/com/cyberark/conjur/springboot/service/CustomPropertySourceChain.java
@@ -24,6 +24,8 @@ public class CustomPropertySourceChain extends PropertyProcessorChain {
 
 	private SecretsApi secretsApi;
 
+	private ConjurConfig conjurConfig;
+
 	public CustomPropertySourceChain(String name) {
 		super("customPropertySource");
 	
@@ -41,6 +43,10 @@ public class CustomPropertySourceChain extends PropertyProcessorChain {
 		this.secretsApi = secretsApi;
 	}
 
+	public void setConjurConfig(ConjurConfig conjurConfig) {
+		this.conjurConfig = conjurConfig;
+	}
+
 	@Override
 	public String[] getPropertyNames() {
 
@@ -52,7 +58,7 @@ public class CustomPropertySourceChain extends PropertyProcessorChain {
 
 		byte[] result = null;
 
-		key = ConjurConfig.getInstance().mapProperty(key);
+		key = conjurConfig.mapProperty(key);
 
 		if (!(key.startsWith(ConjurConstant.SPRING_VAR)) && !(key.startsWith(ConjurConstant.SERVER_VAR))
 				&& !(key.startsWith(ConjurConstant.ERROR)) && !(key.startsWith(ConjurConstant.SPRING_UTIL))

--- a/src/test/java/com/cyberark/conjur/springboot/core/env/ConjurConfigTest.java
+++ b/src/test/java/com/cyberark/conjur/springboot/core/env/ConjurConfigTest.java
@@ -1,0 +1,30 @@
+package com.cyberark.conjur.springboot.core.env;
+
+import com.cyberark.conjur.sdk.ApiException;
+import com.cyberark.conjur.springboot.annotations.ConjurPropertySource;
+import com.cyberark.conjur.springboot.processor.SpringBootConjurAutoConfiguration;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author bnasslahsen
+ */
+@SpringBootTest(classes = SpringBootConjurAutoConfiguration.class)
+@ConjurPropertySource({})
+public class ConjurConfigTest {
+
+	@Autowired
+	private ConjurConfig conjurConfig;
+	
+	@Test
+	public void testGetMappings() throws ApiException {
+		assertEquals("vault/bnl-k8s-safe/mysql-test-db/dsn", conjurConfig.mapProperty("testUrl"));
+		assertEquals("vault/bnl-k8s-safe/mysql-test-db/username", conjurConfig.mapProperty("testUsername"));
+	}
+	
+
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 logging.level.com.cyberark = DEBUG
 conjur.authn_api_key=***REMOVED***
+conjur.mapping-path=classpath:mapping-dir/conjur.properties

--- a/src/test/resources/mapping-dir/conjur.properties
+++ b/src/test/resources/mapping-dir/conjur.properties
@@ -1,0 +1,3 @@
+conjur.mapping.testUrl=vault/bnl-k8s-safe/mysql-test-db/dsn
+conjur.mapping.testUsername=vault/bnl-k8s-safe/mysql-test-db/username
+


### PR DESCRIPTION
### Desired Outcome

* The goal of this PR is to make the path of `conjur.properties` configurable through spring-boot properties
* The current is hardcoding the path of the `conjur.properties`, making it possible to declare the path of secrets after the binary (jars, docker images, ...) are built.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

This PR introduces new property `conjur.mapping-path` that allow the developer to explicitly set the path of `conjur.properties`


### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
