### PR TITLE
(Sonar) Fixed finding: "`@Override` should be used on overriding and …

### DIFF
--- a/src/main/java/com/cyberark/conjur/springboot/processor/ConjurValueClassProcessor.java
+++ b/src/main/java/com/cyberark/conjur/springboot/processor/ConjurValueClassProcessor.java
@@ -69,6 +69,7 @@ public class ConjurValueClassProcessor implements BeanPostProcessor {
 	}
 
 	@Nullable
+	@Override
 	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 		return bean;
 	}


### PR DESCRIPTION
## Remediation

This change fixes "`@Override` should be used on overriding and implementing methods" (id = [java:S1161](https://rules.sonarsource.com/java/RSPEC-1161/)) identified by Sonar.

## Details

This change adds missing `@Override` to known subclasses. Documenting inheritance will help readers and static analysis tools understand the code better, spot bugs easier, and in general lead to more efficient and effective review.

Our changes look something like this:

```diff
  interface AcmeParent {
     void doThing();
  } 

  class AcmeChild implements AcmeParent {

+   @Override
    void doThing() {
      thing();
    }
    
  }
```

<details>
  <summary>More reading</summary>

  * [https://rules.sonarsource.com/java/RSPEC-1161/](https://rules.sonarsource.com/java/RSPEC-1161/)
</details>

🧚🤖  Powered by Pixeebot  