### PR TITLE
(Sonar) Fixed finding: "Utility classes should not have public constructors"

### DIFF
--- a/src/main/java/com/cyberark/conjur/springboot/constant/ConjurConstant.java
+++ b/src/main/java/com/cyberark/conjur/springboot/constant/ConjurConstant.java
@@ -7,6 +7,9 @@ package com.cyberark.conjur.springboot.constant;
  */
 public class ConjurConstant {
 
+private ConjurConstant() {
+}
+
 	/**
 	 * Generic extension for properties define at conjur.properties.
 	 */


### PR DESCRIPTION
## Remediation

This change fixes "Utility classes should not have public constructors" (id = [java:S1118](https://rules.sonarsource.com/java/RSPEC-1118/)) identified by Sonar.

## Details

This change adds private constructors to utility classes. Utility classes are only meant to be accessed statically. Since they're not meant to be instantiated, we can use the Java's code visibility protections to hide the constructor and prevent unintended or malicious access.

Our changes look something like this:

```diff
   public class Utils {
+    private Utils() {}
     ...
```

<details>
  <summary>More reading</summary>

  * [https://rules.sonarsource.com/java/RSPEC-1118/](https://rules.sonarsource.com/java/RSPEC-1118/)
</details>

🧚🤖  Powered by Pixeebot  
